### PR TITLE
4.1.0 (#324)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,14 @@ function getData([col, row]: Item): GridCell {
             kind: GridCellKind.Text,
             data: person.firstName,
             allowOverlay: false,
+            displayData: person.firstName
         };
     } else if (col === 1) {
         return {
             kind: GridCellKind.Text,
             data: person.lastName,
             allowOverlay: false,
+            displayData: person.lastName
         };
     } else {
         throw new Error();

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,7 +7,7 @@ npm install
 
 function update {
     echo $1 $2
-    jq "$1" $2 > $2.tmp
+    jq --indent 4 "$1" $2 > $2.tmp
     mv $2.tmp $2
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "root",
-    "version": "4.0.3",
+    "version": "4.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "root",
-    "version": "4.0.3",
+    "version": "4.1.0",
     "scripts": {
         "start": "npm run storybook",
         "bootstrap": "./bootstrap.sh",

--- a/packages/cells/package.json
+++ b/packages/cells/package.json
@@ -1,61 +1,61 @@
 {
-  "name": "@glideapps/glide-data-grid-cells",
-  "version": "4.0.3",
-  "description": "Extra cells for glide-data-grid",
-  "sideEffects": false,
-  "type": "module",
-  "browser": "dist/js/index.js",
-  "main": "dist/cjs/index.js",
-  "module": "dist/js/index.js",
-  "types": "dist/ts/index.d.ts",
-  "exports": {
-    "import": "./dist/js/index.js",
-    "require": "./dist/cjs/index.js"
-  },
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "npm run build-js && npm run build-cjs && npm run build-types",
-    "build-js": "babel --config-file ../../babel.config.json ./src -d dist/js --ignore '**/*.stories.tsx','src/stories/*.tsx' --extensions .ts,.tsx && tsc-esm-fix --target='dist/js'",
-    "build-cjs": "babel --config-file ../../babel.cjs.json ./src -d dist/cjs --ignore '**/*.stories.tsx','src/stories/*.tsx' --extensions .ts,.tsx",
-    "build-types": "tsc -p tsconfig.types.json",
-    "lint": "eslint src --ext .ts,.tsx"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/glideapps/glide-data-grid.git",
-    "directory": "packages/cells"
-  },
-  "homepage": "https://github.com/glideapps/glide-data-grid/tree/main/cells",
-  "author": "Glide",
-  "license": "MIT",
-  "keywords": [
-    "react",
-    "datagrid",
-    "data-grid",
-    "editor",
-    "reactjs",
-    "scrolling",
-    "data",
-    "table",
-    "cell",
-    "canvas"
-  ],
-  "dependencies": {
-    "@glideapps/glide-data-grid": "4.0.3",
-    "@toast-ui/editor": "^3.1.3",
-    "@toast-ui/react-editor": "^3.1.3",
-    "react-select": "^5.2.2"
-  },
-  "devDependencies": {
-    "@babel/cli": "^7.16.0",
-    "@types/prosemirror-commands": "^1.0.4",
-    "@types/react": "16.14.21",
-    "eslint": "^7.12.1",
-    "eslint-plugin-import": "^2.22.0",
-    "eslint-plugin-react": "^7.21.5",
-    "eslint-plugin-react-hooks": "^4.2.0",
-    "tsc-esm-fix": "^2.7.8"
-  }
+    "name": "@glideapps/glide-data-grid-cells",
+    "version": "4.1.0",
+    "description": "Extra cells for glide-data-grid",
+    "sideEffects": false,
+    "type": "module",
+    "browser": "dist/js/index.js",
+    "main": "dist/cjs/index.js",
+    "module": "dist/js/index.js",
+    "types": "dist/ts/index.d.ts",
+    "exports": {
+        "import": "./dist/js/index.js",
+        "require": "./dist/cjs/index.js"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "npm run build-js && npm run build-cjs && npm run build-types",
+        "build-js": "babel --config-file ../../babel.config.json ./src -d dist/js --ignore '**/*.stories.tsx','src/stories/*.tsx' --extensions .ts,.tsx && tsc-esm-fix --target='dist/js'",
+        "build-cjs": "babel --config-file ../../babel.cjs.json ./src -d dist/cjs --ignore '**/*.stories.tsx','src/stories/*.tsx' --extensions .ts,.tsx",
+        "build-types": "tsc -p tsconfig.types.json",
+        "lint": "eslint src --ext .ts,.tsx"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/glideapps/glide-data-grid.git",
+        "directory": "packages/cells"
+    },
+    "homepage": "https://github.com/glideapps/glide-data-grid/tree/main/cells",
+    "author": "Glide",
+    "license": "MIT",
+    "keywords": [
+        "react",
+        "datagrid",
+        "data-grid",
+        "editor",
+        "reactjs",
+        "scrolling",
+        "data",
+        "table",
+        "cell",
+        "canvas"
+    ],
+    "dependencies": {
+        "@glideapps/glide-data-grid": "4.1.0",
+        "@toast-ui/editor": "^3.1.3",
+        "@toast-ui/react-editor": "^3.1.3",
+        "react-select": "^5.2.2"
+    },
+    "devDependencies": {
+        "@babel/cli": "^7.16.0",
+        "@types/prosemirror-commands": "^1.0.4",
+        "@types/react": "16.14.21",
+        "eslint": "^7.12.1",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-react": "^7.21.5",
+        "eslint-plugin-react-hooks": "^4.2.0",
+        "tsc-esm-fix": "^2.7.8"
+    }
 }

--- a/packages/cells/src/cell.stories.tsx
+++ b/packages/cells/src/cell.stories.tsx
@@ -2,16 +2,17 @@ import styled from "styled-components";
 import * as React from "react";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { DataEditor, DataEditorProps, GridCellKind } from "@glideapps/glide-data-grid";
-import { useExtraCells } from ".";
+import { DropdownCell as DropdownRenderer, useExtraCells } from ".";
 import { StarCell } from "./cells/star-cell";
 import { SparklineCell } from "./cells/sparkline-cell";
 import range from "lodash/range";
 import uniq from "lodash/uniq";
 import { TagsCell } from "./cells/tags-cell";
 import { UserProfileCell } from "./cells/user-profile-cell";
-import { DropdownCell } from "./cells/dropdown-cell";
+import type { DropdownCell } from "./cells/dropdown-cell";
 import { ArticleCell } from "./cells/article-cell-types";
 import { RangeCell } from "./cells/range-cell";
+import { SpinnerCell } from "./cells/spinner-cell";
 
 const SimpleWrapper = styled.div`
     text-rendering: optimizeLegibility;
@@ -162,14 +163,13 @@ const possibleTags = [
 ];
 
 export const CustomCells: React.VFC = () => {
-    const { drawCell, provideEditor } = useExtraCells();
+    const cellProps = useExtraCells();
 
     return (
         <BeautifulWrapper title="Custom cells" description={<Description>Some of our extension cells.</Description>}>
             <DataEditor
                 {...defaultProps}
-                drawCell={drawCell}
-                provideEditor={provideEditor}
+                {...cellProps}
                 onPaste={true}
                 // eslint-disable-next-line no-console
                 onCellEdited={(...args) => console.log("Edit Cell", ...args)}
@@ -295,6 +295,18 @@ export const CustomCells: React.VFC = () => {
                             },
                         };
                         return d;
+                    } else if (col === 8) {
+                        num = row + 1;
+                        rand();
+                        const d: SpinnerCell = {
+                            kind: GridCellKind.Custom,
+                            allowOverlay: true,
+                            copyData: "4",
+                            data: {
+                                kind: "spinner-cell",
+                            },
+                        };
+                        return d;
                     }
                     throw new Error("Fail");
                 }}
@@ -331,6 +343,10 @@ export const CustomCells: React.VFC = () => {
                         title: "Article",
                         width: 150,
                     },
+                    {
+                        title: "Spinner",
+                        width: 150,
+                    },
                 ]}
                 rows={500}
             />
@@ -338,6 +354,61 @@ export const CustomCells: React.VFC = () => {
     );
 };
 (CustomCells as any).parameters = {
+    options: {
+        showPanel: false,
+    },
+};
+
+export const CustomCellEditing: React.VFC = () => {
+    const cellProps = useExtraCells();
+
+    const data = React.useRef<string[]>([]);
+
+    return (
+        <BeautifulWrapper
+            title="Custom cell editing"
+            description={
+                <Description>
+                    Cells can be edited and responding to copy/paste using the copyData attribute.
+                </Description>
+            }>
+            <DataEditor
+                {...defaultProps}
+                {...cellProps}
+                onPaste={true}
+                onCellEdited={(cell, newVal) => {
+                    if (newVal.kind !== GridCellKind.Custom) return;
+                    if (DropdownRenderer.isMatch(newVal)) {
+                        data.current[cell[1]] = newVal.data.value;
+                    }
+                }}
+                getCellsForSelection={true}
+                getCellContent={cell => {
+                    const [, row] = cell;
+                    const val = data.current[row] ?? "A";
+                    return {
+                        kind: GridCellKind.Custom,
+                        allowOverlay: true,
+                        copyData: val,
+                        data: {
+                            kind: "dropdown-cell",
+                            allowedValues: ["A", "B", "C"],
+                            value: val,
+                        },
+                    } as DropdownCell;
+                }}
+                columns={[
+                    {
+                        title: "Dropdown",
+                        width: 200,
+                    },
+                ]}
+                rows={500}
+            />
+        </BeautifulWrapper>
+    );
+};
+(CustomCellEditing as any).parameters = {
     options: {
         showPanel: false,
     },

--- a/packages/cells/src/cells/article-cell.tsx
+++ b/packages/cells/src/cells/article-cell.tsx
@@ -1,6 +1,6 @@
 import type { ArticleCell } from "./article-cell-types";
 import * as React from "react";
-import { CustomCellRenderer } from "@glideapps/glide-data-grid";
+import { CustomCellRenderer, getMiddleCenterBias } from "@glideapps/glide-data-grid";
 
 const ArticleCellEditor = React.lazy(async () => await import("./article-cell-editor"));
 
@@ -22,7 +22,11 @@ const renderer: CustomCellRenderer<ArticleCell> = {
         }
 
         ctx.fillStyle = theme.textDark;
-        ctx.fillText(data, rect.x + theme.cellHorizontalPadding, rect.y + rect.height / 2);
+        ctx.fillText(
+            data,
+            rect.x + theme.cellHorizontalPadding,
+            rect.y + rect.height / 2 + getMiddleCenterBias(ctx, theme)
+        );
 
         return true;
     },
@@ -44,6 +48,10 @@ const renderer: CustomCellRenderer<ArticleCell> = {
             maxHeight: "unset",
         },
         disablePadding: true,
+    }),
+    onPaste: (val, d) => ({
+        ...d,
+        markdown: val,
     }),
 };
 

--- a/packages/cells/src/cells/dropdown-cell.tsx
+++ b/packages/cells/src/cells/dropdown-cell.tsx
@@ -1,4 +1,4 @@
-import { CustomCell, ProvideEditorCallback, CustomCellRenderer } from "@glideapps/glide-data-grid";
+import { CustomCell, ProvideEditorCallback, CustomCellRenderer, getMiddleCenterBias } from "@glideapps/glide-data-grid";
 import styled from "styled-components";
 import * as React from "react";
 import Select, { MenuProps, components } from "react-select";
@@ -81,7 +81,11 @@ const renderer: CustomCellRenderer<DropdownCell> = {
         const { ctx, theme, rect } = args;
         const { value } = cell.data;
         ctx.fillStyle = theme.textDark;
-        ctx.fillText(value, rect.x + theme.cellHorizontalPadding, rect.y + rect.height / 2);
+        ctx.fillText(
+            value,
+            rect.x + theme.cellHorizontalPadding,
+            rect.y + rect.height / 2 + getMiddleCenterBias(ctx, theme)
+        );
 
         return true;
     },
@@ -96,6 +100,10 @@ const renderer: CustomCellRenderer<DropdownCell> = {
                 value: "",
             },
         }),
+    }),
+    onPaste: (v, d) => ({
+        ...d,
+        value: d.allowedValues.includes(v) ? v : d.value,
     }),
 };
 

--- a/packages/cells/src/cells/range-cell.tsx
+++ b/packages/cells/src/cells/range-cell.tsx
@@ -1,4 +1,4 @@
-import { CustomCell, measureTextCached, CustomCellRenderer } from "@glideapps/glide-data-grid";
+import { CustomCell, measureTextCached, CustomCellRenderer, getMiddleCenterBias } from "@glideapps/glide-data-grid";
 import * as React from "react";
 import { roundedRect } from "../draw-fns";
 
@@ -78,7 +78,11 @@ const renderer: CustomCellRenderer<RangeCell> = {
         if (label !== undefined) {
             ctx.textAlign = "right";
             ctx.fillStyle = theme.textDark;
-            ctx.fillText(label, rect.x + rect.width - theme.cellHorizontalPadding, yMid);
+            ctx.fillText(
+                label,
+                rect.x + rect.width - theme.cellHorizontalPadding,
+                yMid + getMiddleCenterBias(ctx, `12px ${theme.fontFamily}`)
+            );
         }
 
         ctx.restore();
@@ -119,6 +123,14 @@ const renderer: CustomCellRenderer<RangeCell> = {
                     {strValue}
                 </label>
             );
+        };
+    },
+    onPaste: (v, d) => {
+        let num = Number.parseFloat(v);
+        num = Number.isNaN(num) ? d.value : Math.max(d.min, Math.min(d.max, num));
+        return {
+            ...d,
+            value: num,
         };
     },
 };

--- a/packages/cells/src/cells/sparkline-cell.tsx
+++ b/packages/cells/src/cells/sparkline-cell.tsx
@@ -123,6 +123,7 @@ const renderer: CustomCellRenderer<SparklineCell> = {
         return true;
     },
     provideEditor: () => undefined,
+    onPaste: (_v, d) => d,
 };
 
 export default renderer;

--- a/packages/cells/src/cells/spinner-cell.tsx
+++ b/packages/cells/src/cells/spinner-cell.tsx
@@ -1,0 +1,39 @@
+import { CustomCell, CustomCellRenderer } from "@glideapps/glide-data-grid";
+
+interface SpinnerCellProps {
+    readonly kind: "spinner-cell";
+}
+
+export type SpinnerCell = CustomCell<SpinnerCellProps>;
+
+const renderer: CustomCellRenderer<SpinnerCell> = {
+    isMatch: (cell: CustomCell): cell is SpinnerCell => (cell.data as any).kind === "spinner-cell",
+    draw: args => {
+        const { ctx, theme, rect, requestAnimationFrame } = args;
+
+        const progress = (window.performance.now() % 1000) / 1000;
+
+        const x = rect.x + rect.width / 2;
+        const y = rect.y + rect.height / 2;
+        ctx.arc(
+            x,
+            y,
+            Math.min(12, rect.height / 2 - 2),
+            Math.PI * 2 * progress,
+            Math.PI * 2 * progress + Math.PI * 1.5
+        );
+
+        ctx.strokeStyle = theme.textMedium;
+        ctx.lineWidth = 2;
+        ctx.stroke();
+
+        ctx.lineWidth = 1;
+
+        requestAnimationFrame();
+
+        return true;
+    },
+    provideEditor: () => undefined,
+};
+
+export default renderer;

--- a/packages/cells/src/cells/star-cell.tsx
+++ b/packages/cells/src/cells/star-cell.tsx
@@ -115,6 +115,13 @@ const renderer: CustomCellRenderer<StarCell> = {
             </EditorWrap>
         );
     },
+    onPaste: (val, d) => {
+        const num = Number.parseInt(val);
+        return {
+            ...d,
+            rating: Number.isNaN(num) ? 0 : num,
+        };
+    },
 };
 
 export default renderer;

--- a/packages/cells/src/cells/tags-cell.tsx
+++ b/packages/cells/src/cells/tags-cell.tsx
@@ -1,4 +1,10 @@
-import { CustomCell, Rectangle, measureTextCached, CustomCellRenderer } from "@glideapps/glide-data-grid";
+import {
+    CustomCell,
+    Rectangle,
+    measureTextCached,
+    CustomCellRenderer,
+    getMiddleCenterBias,
+} from "@glideapps/glide-data-grid";
 import styled from "styled-components";
 import * as React from "react";
 import { roundedRect } from "../draw-fns";
@@ -112,7 +118,7 @@ const renderer: CustomCellRenderer<TagsCell> = {
             ctx.fill();
 
             ctx.fillStyle = theme.textDark;
-            ctx.fillText(tag, x + innerPad, y + textY);
+            ctx.fillText(tag, x + innerPad, y + textY + getMiddleCenterBias(ctx, `12px ${theme.fontFamily}`));
 
             x += width + 8;
             if (x > drawArea.x + drawArea.width && row >= rows) break;
@@ -160,6 +166,17 @@ const renderer: CustomCellRenderer<TagsCell> = {
             );
         };
     },
+    onPaste: (v, d) => ({
+        ...d,
+        tags: d.possibleTags
+            .map(x => x.tag)
+            .filter(x =>
+                v
+                    .split(",")
+                    .map(s => s.trim())
+                    .includes(x)
+            ),
+    }),
 };
 
 export default renderer;

--- a/packages/cells/src/cells/user-profile-cell.tsx
+++ b/packages/cells/src/cells/user-profile-cell.tsx
@@ -1,6 +1,12 @@
 /* eslint-disable react/display-name */
 import * as React from "react";
-import { CustomCell, measureTextCached, TextCellEntry, CustomCellRenderer } from "@glideapps/glide-data-grid";
+import {
+    CustomCell,
+    measureTextCached,
+    TextCellEntry,
+    CustomCellRenderer,
+    getMiddleCenterBias,
+} from "@glideapps/glide-data-grid";
 
 interface UserProfileCellProps {
     readonly kind: "user-profile-cell";
@@ -39,7 +45,7 @@ const renderer: CustomCellRenderer<UserProfileCell> = {
         ctx.fillText(
             initial[0],
             drawX + radius - metrics.width / 2,
-            rect.y + rect.height / 2 + metrics.actualBoundingBoxAscent / 2
+            rect.y + rect.height / 2 + getMiddleCenterBias(ctx, `600 16px ${theme.fontFamily}`)
         );
 
         if (imageResult !== undefined) {
@@ -56,8 +62,7 @@ const renderer: CustomCellRenderer<UserProfileCell> = {
         if (name !== undefined) {
             ctx.font = `${theme.baseFontStyle} ${theme.fontFamily}`;
             ctx.fillStyle = theme.textDark;
-            ctx.textBaseline = "middle";
-            ctx.fillText(name, drawX + radius * 2 + xPad, rect.y + rect.height / 2);
+            ctx.fillText(name, drawX + radius * 2 + xPad, rect.y + rect.height / 2 + getMiddleCenterBias(ctx, theme));
         }
 
         ctx.restore();
@@ -83,6 +88,10 @@ const renderer: CustomCellRenderer<UserProfileCell> = {
             />
         );
     },
+    onPaste: (v, d) => ({
+        ...d,
+        name: v,
+    }),
 };
 
 export default renderer;

--- a/packages/cells/src/index.ts
+++ b/packages/cells/src/index.ts
@@ -1,4 +1,4 @@
-import {  DataEditorProps, ProvideEditorCallback, GridCell, useCustomCells } from "@glideapps/glide-data-grid";
+import { DataEditorProps, ProvideEditorCallback, GridCell, useCustomCells } from "@glideapps/glide-data-grid";
 import StarCellRenderer from "./cells/star-cell";
 import SparklineCellRenderer from "./cells/sparkline-cell";
 import TagsCellRenderer from "./cells/tags-cell";
@@ -6,6 +6,7 @@ import UserProfileCellRenderer from "./cells/user-profile-cell";
 import DropdownCellRenderer from "./cells/dropdown-cell";
 import ArticleCellRenderer from "./cells/article-cell";
 import RangeCellRenderer from "./cells/range-cell";
+import SpinnerCellRenderer from "./cells/spinner-cell";
 
 type DrawCallback = NonNullable<DataEditorProps["drawCell"]>;
 
@@ -16,6 +17,7 @@ const cells = [
     UserProfileCellRenderer,
     DropdownCellRenderer,
     ArticleCellRenderer,
+    SpinnerCellRenderer,
     RangeCellRenderer,
 ];
 
@@ -26,7 +28,7 @@ export function useExtraCells(): {
     return useCustomCells(cells);
 }
 
-export { 
+export {
     StarCellRenderer as StarCell,
     SparklineCellRenderer as SparklineCell,
     TagsCellRenderer as TagsCell,
@@ -34,4 +36,4 @@ export {
     DropdownCellRenderer as DropdownCell,
     ArticleCellRenderer as ArticleCell,
     RangeCellRenderer as RangeCell,
- };
+};

--- a/packages/cells/tsconfig.types.json
+++ b/packages/cells/tsconfig.types.json
@@ -1,4 +1,3 @@
-
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
@@ -6,10 +5,11 @@
         "declaration": true,
         "types": ["react", "jest"],
         "isolatedModules": false,
+        "lib": ["ESNext", "DOM", "DOM.Iterable"],
         "noEmit": false,
         "allowJs": false,
         "emitDeclarationOnly": true,
-        "sourceMap": false,
+        "sourceMap": false
     },
     "exclude": ["./src/**/*.stories.tsx", "./src/stories/*.tsx", "./src/docs/*.tsx"]
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -73,12 +73,14 @@ function getData([col, row]: Item): GridCell {
             kind: GridCellKind.Text,
             data: person.firstName,
             allowOverlay: false,
+            displayData: person.firstName
         };
     } else if (col === 1) {
         return {
             kind: GridCellKind.Text,
             data: person.lastName,
             allowOverlay: false,
+            displayData: person.lastName
         };
     } else {
         throw new Error();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,71 +1,71 @@
 {
-  "name": "@glideapps/glide-data-grid",
-  "version": "4.0.3",
-  "description": "Super fast, pure canvas Data Grid Editor",
-  "sideEffects": false,
-  "type": "module",
-  "browser": "dist/js/index.js",
-  "main": "dist/cjs/index.js",
-  "module": "dist/js/index.js",
-  "types": "dist/ts/index.d.ts",
-  "exports": {
-    "import": "./dist/js/index.js",
-    "require": "./dist/cjs/index.js"
-  },
-  "scripts": {
-    "build": "npm run build-js && npm run build-cjs && npm run build-types",
-    "build-js": "babel --config-file ../../babel.config.json ./src -d dist/js --ignore 'src/setupTests.ts','src/docs','**/*.test.ts','**/*.test.tsx','**/*.stories.tsx','src/stories/*.tsx','**/*.d.ts' --extensions .ts,.tsx && tsc-esm-fix --target='dist/js'",
-    "build-cjs": "babel --config-file ../../babel.cjs.json ./src -d dist/cjs --ignore 'src/setupTests.ts','src/docs','**/*.test.ts','**/*.test.tsx','**/*.stories.tsx','src/stories/*.tsx','**/*.d.ts' --extensions .ts,.tsx",
-    "build-types": "tsc -p tsconfig.types.json",
-    "lint": "npm run cycle-check && eslint src --ext .ts,.tsx",
-    "cycle-check": "ts-helper -p ./tsconfig.json -r ./src/index.ts -c",
-    "test": "jest",
-    "check-package": "package-check"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/glideapps/glide-data-grid.git",
-    "directory": "packages/core"
-  },
-  "keywords": [
-    "react",
-    "datagrid",
-    "data-grid",
-    "editor",
-    "reactjs",
-    "scrolling",
-    "data",
-    "table",
-    "cell",
-    "canvas"
-  ],
-  "author": "Glide",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/glideapps/glide-data-grid/issues"
-  },
-  "homepage": "https://grid.glideapps.com",
-  "dependencies": {
-    "react-number-format": "^4.4.1",
-    "react-virtualized-auto-sizer": "^1.0.2"
-  },
-  "peerDependencies": {
-    "lodash": "^4.17.19",
-    "marked": "^4.0.10",
-    "react-responsive-carousel": "^3.2.7",
-    "react": "^16.12.0 || 17.x || 18.x",
-    "react-dom": "^16.12.0 || 17.x || 18.x",
-    "styled-components": "^5.2.0"
-  },
-  "devDependencies": {
-    "@babel/cli": "^7.16.0",
-    "@glideapps/ts-helper": "0.0.5",
-    "@skypack/package-check": "^0.2.2",
-    "eslint": "^7.12.1",
-    "eslint-plugin-import": "^2.22.0",
-    "eslint-plugin-react": "^7.21.5",
-    "eslint-plugin-react-hooks": "^4.2.0",
-    "jest": "^27.4.2",
-    "tsc-esm-fix": "^2.7.8"
-  }
+    "name": "@glideapps/glide-data-grid",
+    "version": "4.1.0",
+    "description": "Super fast, pure canvas Data Grid Editor",
+    "sideEffects": false,
+    "type": "module",
+    "browser": "dist/js/index.js",
+    "main": "dist/cjs/index.js",
+    "module": "dist/js/index.js",
+    "types": "dist/ts/index.d.ts",
+    "exports": {
+        "import": "./dist/js/index.js",
+        "require": "./dist/cjs/index.js"
+    },
+    "scripts": {
+        "build": "npm run build-js && npm run build-cjs && npm run build-types",
+        "build-js": "babel --config-file ../../babel.config.json ./src -d dist/js --ignore 'src/setupTests.ts','src/docs','**/*.test.ts','**/*.test.tsx','**/*.stories.tsx','src/stories/*.tsx','**/*.d.ts' --extensions .ts,.tsx && tsc-esm-fix --target='dist/js'",
+        "build-cjs": "babel --config-file ../../babel.cjs.json ./src -d dist/cjs --ignore 'src/setupTests.ts','src/docs','**/*.test.ts','**/*.test.tsx','**/*.stories.tsx','src/stories/*.tsx','**/*.d.ts' --extensions .ts,.tsx",
+        "build-types": "tsc -p tsconfig.types.json",
+        "lint": "npm run cycle-check && eslint src --ext .ts,.tsx",
+        "cycle-check": "ts-helper -p ./tsconfig.json -r ./src/index.ts -c",
+        "test": "jest",
+        "check-package": "package-check"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/glideapps/glide-data-grid.git",
+        "directory": "packages/core"
+    },
+    "keywords": [
+        "react",
+        "datagrid",
+        "data-grid",
+        "editor",
+        "reactjs",
+        "scrolling",
+        "data",
+        "table",
+        "cell",
+        "canvas"
+    ],
+    "author": "Glide",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/glideapps/glide-data-grid/issues"
+    },
+    "homepage": "https://grid.glideapps.com",
+    "dependencies": {
+        "react-number-format": "^4.4.1",
+        "react-virtualized-auto-sizer": "^1.0.2"
+    },
+    "peerDependencies": {
+        "lodash": "^4.17.19",
+        "marked": "^4.0.10",
+        "react-responsive-carousel": "^3.2.7",
+        "react": "^16.12.0 || 17.x || 18.x",
+        "react-dom": "^16.12.0 || 17.x || 18.x",
+        "styled-components": "^5.2.0"
+    },
+    "devDependencies": {
+        "@babel/cli": "^7.16.0",
+        "@glideapps/ts-helper": "0.0.5",
+        "@skypack/package-check": "^0.2.2",
+        "eslint": "^7.12.1",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-react": "^7.21.5",
+        "eslint-plugin-react-hooks": "^4.2.0",
+        "jest": "^27.4.2",
+        "tsc-esm-fix": "^2.7.8"
+    }
 }

--- a/packages/core/src/data-editor/data-editor-fns.test.ts
+++ b/packages/core/src/data-editor/data-editor-fns.test.ts
@@ -1,0 +1,26 @@
+import { decodeHTML } from "./data-editor-fns";
+
+describe("data-editor-fns", () => {
+    test("decode html", () => {
+        const root = document.createElement("table");
+        root.innerHTML = `
+            <tbody>
+                <tr>
+                    <td>1</td>
+                    <td>2</td>
+                </tr>
+                <tr>
+                    <td>3</td>
+                    <td>4</td>
+                </tr>
+            </tbody>
+        `;
+
+        const decoded = decodeHTML(root);
+
+        expect(decoded).toEqual([
+            ["1", "2"],
+            ["3", "4"],
+        ]);
+    });
+});

--- a/packages/core/src/data-editor/data-editor-fns.ts
+++ b/packages/core/src/data-editor/data-editor-fns.ts
@@ -1,6 +1,13 @@
 import { assertNever } from "../common/support";
 import { DataGridSearchProps } from "../data-grid-search/data-grid-search";
-import { GridCell, GridCellKind, GridSelection, Rectangle } from "../data-grid/data-grid-types";
+import {
+    BooleanEmpty,
+    BooleanIndeterminate,
+    GridCell,
+    GridCellKind,
+    GridSelection,
+    Rectangle,
+} from "../data-grid/data-grid-types";
 
 export function expandSelection(
     newVal: GridSelection,
@@ -165,21 +172,74 @@ export function unquote(str: string): string[][] {
     return result;
 }
 
-export function copyToClipboard(cells: readonly (readonly GridCell[])[], columnIndexes: readonly number[]) {
+export function decodeHTML(tableEl: HTMLTableElement): string[][] | undefined {
+    const walkEl: Element[] = [tableEl];
+    const result: string[][] = [];
+    let current: string[] | undefined;
+
+    while (walkEl.length > 0) {
+        const el = walkEl.pop();
+
+        if (el === undefined) break;
+
+        if (el instanceof HTMLTableElement || el.nodeName === "TBODY") {
+            walkEl.push(...[...el.children].reverse());
+        } else if (el instanceof HTMLTableRowElement) {
+            if (current !== undefined) {
+                result.push(current);
+            }
+            current = [];
+            walkEl.push(...[...el.children].reverse());
+        } else if (el instanceof HTMLTableCellElement) {
+            current?.push(el.innerText ?? el.textContent ?? "");
+        }
+    }
+
+    if (current !== undefined) {
+        result.push(current);
+    }
+
+    return result;
+}
+
+export function copyToClipboard(
+    cells: readonly (readonly GridCell[])[],
+    columnIndexes: readonly number[],
+    e?: ClipboardEvent
+) {
     function escape(str: string): string {
-        if (/\n|"|\t/.test(str)) {
-            str = `"${str.replace(/"/g, `""`)}"`;
+        if (/[\n"\t]/.test(str)) {
+            str = `"${str.replace(/"/g, '""')}"`;
         }
         return str;
     }
 
-    const formatCell = (cell: GridCell, index: number): string => {
+    const formatBoolean = (val: boolean | BooleanEmpty | BooleanIndeterminate): string => {
+        switch (val) {
+            case true:
+                return "TRUE";
+
+            case false:
+                return "FALSE";
+
+            case BooleanIndeterminate:
+                return "INDETERMINATE";
+
+            case BooleanEmpty:
+                return "";
+
+            default:
+                assertNever(val);
+        }
+    };
+
+    const formatCell = (cell: GridCell, index: number, raw: boolean): string => {
         const colIndex = columnIndexes[index];
         if (cell.span !== undefined && cell.span[0] !== colIndex) return "";
         switch (cell.kind) {
             case GridCellKind.Text:
             case GridCellKind.Number:
-                return escape(cell.displayData);
+                return escape(raw ? cell.data?.toString() ?? "" : cell.displayData);
             case GridCellKind.Markdown:
             case GridCellKind.RowID:
             case GridCellKind.Uri:
@@ -188,11 +248,11 @@ export function copyToClipboard(cells: readonly (readonly GridCell[])[], columnI
             case GridCellKind.Bubble:
                 return cell.data.reduce((pv, cv) => `${escape(pv)},${escape(cv)}`);
             case GridCellKind.Boolean:
-                return cell.data ? "TRUE" : "FALSE";
+                return formatBoolean(cell.data);
             case GridCellKind.Loading:
-                return "#LOADING";
+                return raw ? "" : "#LOADING";
             case GridCellKind.Protected:
-                return "************";
+                return raw ? "" : "************";
             case GridCellKind.Drilldown:
                 return cell.data.map(i => i.text).reduce((pv, cv) => `${escape(pv)},${escape(cv)}`);
             case GridCellKind.Custom:
@@ -202,6 +262,48 @@ export function copyToClipboard(cells: readonly (readonly GridCell[])[], columnI
         }
     };
 
-    const str = cells.map(row => row.map(formatCell).join("\t")).join("\n");
-    void window.navigator.clipboard.writeText(str);
+    const str = cells.map(row => row.map((a, b) => formatCell(a, b, false)).join("\t")).join("\n");
+
+    if (window.navigator.clipboard.write !== undefined || e !== undefined) {
+        const rootEl = document.createElement("tbody");
+
+        for (const row of cells) {
+            const rowEl = document.createElement("tr");
+
+            for (let i = 0; i < row.length; i++) {
+                const cell = row[i];
+                const cellEl = document.createElement("td");
+                if (cell.kind === GridCellKind.Uri) {
+                    const link = document.createElement("a");
+                    link.href = cell.data;
+                    link.innerText = cell.data;
+                    cellEl.appendChild(link);
+                } else {
+                    cellEl.innerText = formatCell(cell, i, true);
+                }
+                rowEl.appendChild(cellEl);
+            }
+
+            rootEl.appendChild(rowEl);
+        }
+        if (window.navigator.clipboard.write !== undefined) {
+            void window.navigator.clipboard.write([
+                new ClipboardItem({
+                    "text/plain": new Blob([str], { type: "text/plain" }),
+                    "text/html": new Blob([`<table>${rootEl.outerHTML}</table>`], { type: "text/html" }),
+                }),
+            ]);
+        } else if (e !== undefined && e?.clipboardData !== null) {
+            try {
+                // This might fail if we had to await the thunk
+                e.clipboardData.setData("text/plain", str);
+                e.clipboardData.setData("text/html", `<table>${rootEl.outerHTML}</table>`);
+                e.preventDefault();
+            } catch {
+                void window.navigator.clipboard.writeText(str);
+            }
+        }
+    } else {
+        void window.navigator.clipboard.writeText(str);
+    }
 }

--- a/packages/core/src/data-editor/data-editor-input.test.tsx
+++ b/packages/core/src/data-editor/data-editor-input.test.tsx
@@ -55,8 +55,7 @@ const makeCell = (cell: Item): GridCell => {
             kind: GridCellKind.Boolean,
             allowOverlay: false,
             data: row % 2 === 0,
-            allowEdit: true,
-            showUnchecked: true,
+            readonly: false,
         };
     } else if (col === 8) {
         return {

--- a/packages/core/src/data-editor/data-editor.test.tsx
+++ b/packages/core/src/data-editor/data-editor.test.tsx
@@ -12,6 +12,7 @@ import {
     Item,
 } from "..";
 import { DataEditorRef } from "./data-editor";
+import { SizedGridColumn } from "../data-grid/data-grid-types";
 
 jest.mock("react-virtualized-auto-sizer", () => {
     return {
@@ -20,6 +21,11 @@ jest.mock("react-virtualized-auto-sizer", () => {
         foo: "mocked foo",
     };
 });
+
+const BOOLEAN_DATA_LOOKUP: (boolean | null | undefined)[] = [true, false, undefined, null];
+function getMockBooleanData(row: number): boolean | null | undefined {
+    return BOOLEAN_DATA_LOOKUP[row % BOOLEAN_DATA_LOOKUP.length];
+}
 
 const makeCell = (cell: Item): GridCell => {
     const [col, row] = cell;
@@ -62,9 +68,8 @@ const makeCell = (cell: Item): GridCell => {
         return {
             kind: GridCellKind.Boolean,
             allowOverlay: false,
-            data: row % 2 === 0,
-            allowEdit: true,
-            showUnchecked: true,
+            data: getMockBooleanData(row),
+            readonly: false,
         };
     } else if (col === 8) {
         return {
@@ -87,6 +92,7 @@ const makeCell = (cell: Item): GridCell => {
         displayData: `${col}, ${row}`,
     };
 };
+
 const basicProps: DataEditorProps = {
     columns: [
         {
@@ -153,6 +159,18 @@ const basicProps: DataEditorProps = {
     },
     rows: 1000,
 };
+
+function getCellCenterPositionForDefaultGrid(cell: Item): [number, number] {
+    const [col, row] = cell;
+
+    const xStart = basicProps.columns.slice(0, col).reduce((acc, curr) => acc + (curr as SizedGridColumn).width, 0);
+    const xOffset = (basicProps.columns[col] as SizedGridColumn).width / 2;
+
+    const yStart = (basicProps.headerHeight as number) + row * (basicProps.rowHeight as number);
+    const yOffset = (basicProps.rowHeight as number) / 2;
+
+    return [xStart + xOffset, yStart + yOffset];
+}
 
 beforeEach(() => {
     Element.prototype.scrollTo = jest.fn();
@@ -247,6 +265,10 @@ const EventedDataEditor = React.forwardRef<DataEditorRef, DataEditorProps>((p, r
 });
 
 describe("data-editor", () => {
+    afterEach(() => {
+        jest.clearAllTimers();
+    });
+
     test("Focus a11y cell", async () => {
         const spy = jest.fn();
         jest.useFakeTimers();
@@ -480,8 +502,13 @@ describe("data-editor", () => {
 
         const overlay = screen.getByDisplayValue("j");
 
+        jest.useFakeTimers();
         fireEvent.keyDown(overlay, {
             key: "Enter",
+        });
+
+        act(() => {
+            jest.runAllTimers();
         });
 
         expect(spy).toBeCalledWith({ allowOverlay: true, data: "j", displayData: "1, 1", kind: "text" }, [0, 1]);
@@ -930,8 +957,13 @@ describe("data-editor", () => {
         const overlay = screen.getByDisplayValue("Data: 1, 1");
         expect(overlay).toBeInTheDocument();
 
+        jest.useFakeTimers();
         fireEvent.keyDown(canvas, {
             key: "Escape",
+        });
+
+        act(() => {
+            jest.runAllTimers();
         });
 
         expect(overlay).not.toBeInTheDocument();
@@ -968,8 +1000,12 @@ describe("data-editor", () => {
         const overlay = screen.getByText("Header: 9, 1");
         expect(overlay).toBeInTheDocument();
 
+        jest.useFakeTimers();
         fireEvent.keyDown(canvas, {
             key: "Escape",
+        });
+        act(() => {
+            jest.runAllTimers();
         });
 
         expect(overlay).not.toBeInTheDocument();
@@ -1006,8 +1042,13 @@ describe("data-editor", () => {
         const overlay = screen.getByDisplayValue("j");
         expect(overlay).toBeInTheDocument();
 
-        fireEvent.keyDown(canvas, {
+        jest.useFakeTimers();
+        fireEvent.keyDown(overlay, {
             key: "Escape",
+        });
+
+        act(() => {
+            jest.runAllTimers();
         });
 
         expect(overlay).not.toBeInTheDocument();
@@ -1045,12 +1086,70 @@ describe("data-editor", () => {
         const overlay = screen.getByDisplayValue("j");
         expect(overlay).toBeInTheDocument();
 
+        jest.useFakeTimers();
         fireEvent.keyDown(overlay, {
             key: "Enter",
         });
 
+        act(() => {
+            jest.runAllTimers();
+        });
+
         expect(spy).toBeCalledWith([1, 1], expect.objectContaining({ data: "j" }));
         expect(overlay).not.toBeInTheDocument();
+    });
+
+    test("Directly toggle booleans", async () => {
+        const spy = jest.fn();
+        jest.useFakeTimers();
+        const ref = React.createRef<DataEditorRef>();
+        render(<DataEditor {...basicProps} onCellEdited={spy} ref={ref} />, {
+            wrapper: Context,
+        });
+        prep(false);
+
+        const canvas = screen.getByTestId("data-grid-canvas");
+
+        // We need to be focused on the grid for booleans to toggle automatically
+        act(() => {
+            ref.current?.focus();
+        });
+        act(() => {
+            jest.runAllTimers();
+        });
+        jest.useRealTimers();
+
+        // [7, 0] is a checked boolean
+        const [checkedX, checkedY] = getCellCenterPositionForDefaultGrid([7, 0]);
+
+        fireEvent.mouseDown(canvas, { clientX: checkedX, clientY: checkedY });
+        fireEvent.mouseUp(canvas, { clientX: checkedX, clientY: checkedY });
+
+        expect(spy).toBeCalledWith([7, 0], expect.objectContaining({ data: false }));
+
+        // [7, 1] is an unchecked boolean
+        const [uncheckedX, uncheckedY] = getCellCenterPositionForDefaultGrid([7, 1]);
+
+        fireEvent.mouseDown(canvas, { clientX: uncheckedX, clientY: uncheckedY });
+        fireEvent.mouseUp(canvas, { clientX: uncheckedX, clientY: uncheckedY });
+
+        expect(spy).toBeCalledWith([7, 1], expect.objectContaining({ data: true }));
+
+        // [7, 2] is an indeterminate boolean
+        const [indeterminateX, indeterminateY] = getCellCenterPositionForDefaultGrid([7, 2]);
+
+        fireEvent.mouseDown(canvas, { clientX: indeterminateX, clientY: indeterminateY });
+        fireEvent.mouseUp(canvas, { clientX: indeterminateX, clientY: indeterminateY });
+
+        expect(spy).toBeCalledWith([7, 2], expect.objectContaining({ data: true }));
+
+        // [7, 3] is an empty boolean
+        const [emptyX, emptyY] = getCellCenterPositionForDefaultGrid([7, 3]);
+
+        fireEvent.mouseDown(canvas, { clientX: emptyX, clientY: emptyY });
+        fireEvent.mouseUp(canvas, { clientX: emptyX, clientY: emptyY });
+
+        expect(spy).toBeCalledWith([7, 3], expect.objectContaining({ data: true }));
     });
 
     test("Arrow left", async () => {
@@ -1266,10 +1365,13 @@ describe("data-editor", () => {
         render(<EventedDataEditor {...basicProps} showSearch={true} onSearchClose={spy} />, {
             wrapper: Context,
         });
-        prep();
+        prep(false);
 
         const searchClose = screen.getByTestId("search-close-button");
         fireEvent.click(searchClose);
+        act(() => {
+            jest.runAllTimers();
+        });
         expect(spy).toBeCalled();
     });
 
@@ -1324,7 +1426,7 @@ describe("data-editor", () => {
                 wrapper: Context,
             }
         );
-        prep();
+        prep(false);
 
         const canvas = screen.getByTestId("data-grid-canvas");
         jest.spyOn(document, "activeElement", "get").mockImplementation(() => canvas);
@@ -1338,10 +1440,18 @@ describe("data-editor", () => {
             clientY: 36 + 32 * 2 + 16, // Row 2 (0 indexed)
         });
 
+        act(() => {
+            jest.runAllTimers();
+        });
+
         spy.mockClear();
         fireEvent.keyDown(canvas, {
             key: "ArrowRight",
             shiftKey: true,
+        });
+
+        act(() => {
+            jest.runAllTimers();
         });
 
         expect(spy).toBeCalledWith(
@@ -1351,7 +1461,9 @@ describe("data-editor", () => {
         );
 
         fireEvent.copy(window);
-        await new Promise(resolve => setTimeout(resolve, 10));
+        act(() => {
+            jest.runAllTimers();
+        });
         expect(navigator.clipboard.writeText).toBeCalledWith("1, 2\t2, 2");
 
         spy.mockClear();
@@ -1362,7 +1474,11 @@ describe("data-editor", () => {
         expect(spy).toBeCalledWith(expect.objectContaining({ current: expect.objectContaining({ cell: [1, 3] }) }));
 
         fireEvent.paste(window);
-        await new Promise(resolve => setTimeout(resolve, 10));
+        act(() => {
+            jest.runAllTimers();
+        });
+        jest.useRealTimers();
+        await new Promise(r => window.setTimeout(r, 10));
         expect(pasteSpy).toBeCalledWith(
             [1, 3],
             [
@@ -1396,7 +1512,7 @@ describe("data-editor", () => {
                 wrapper: Context,
             }
         );
-        prep();
+        prep(false);
 
         const canvas = screen.getByTestId("data-grid-canvas");
         jest.spyOn(document, "activeElement", "get").mockImplementation(() => canvas);
@@ -1408,6 +1524,10 @@ describe("data-editor", () => {
         fireEvent.mouseUp(canvas, {
             clientX: 300, // Col B
             clientY: 36 + 32 * 2 + 16, // Row 2 (0 indexed)
+        });
+
+        act(() => {
+            jest.runAllTimers();
         });
 
         spy.mockClear();
@@ -1423,7 +1543,9 @@ describe("data-editor", () => {
         );
 
         fireEvent.copy(window);
-        await new Promise(resolve => setTimeout(resolve, 10));
+        act(() => {
+            jest.runAllTimers();
+        });
         expect(navigator.clipboard.writeText).toBeCalledWith("1, 2\t2, 2");
 
         spy.mockClear();
@@ -1434,6 +1556,10 @@ describe("data-editor", () => {
         expect(spy).toBeCalledWith(expect.objectContaining({ current: expect.objectContaining({ cell: [1, 3] }) }));
 
         fireEvent.paste(window);
+        act(() => {
+            jest.runAllTimers();
+        });
+        jest.useRealTimers();
         await new Promise(resolve => setTimeout(resolve, 10));
         expect(pasteSpy).toBeCalledWith(
             [1, 3],
@@ -2479,6 +2605,10 @@ describe("data-editor", () => {
         // const canvas = screen.getByTestId("data-grid-canvas");
 
         if (scroller !== null) {
+            const mockDownEv = createEvent.mouseDown(scroller);
+            fireEvent(scroller, mockDownEv);
+            expect(mockDownEv.defaultPrevented).toBe(false);
+
             const mockEv = createEvent.dragStart(scroller);
             Object.assign(mockEv, {
                 clientX: 100,
@@ -2746,28 +2876,6 @@ describe("data-editor", () => {
                 current: expect.objectContaining({ cell: [0, 0], range: { x: 0, y: 0, width: cols, height: 1000 } }),
             })
         );
-
-        // spy.mockClear();
-        // fireEvent.keyDown(canvas, {
-        //     key: "ArrowUp",
-        //     ctrlKey: true,
-        //     shiftKey: true,
-        // });
-
-        // expect(spy).toBeCalledWith(
-        //     expect.objectContaining({ cell: [0, 0], range: { x: 0, y: 0, width: cols, height: 1 } })
-        // );
-
-        // spy.mockClear();
-        // fireEvent.keyDown(canvas, {
-        //     key: "ArrowLeft",
-        //     ctrlKey: true,
-        //     shiftKey: true,
-        // });
-
-        // expect(spy).toBeCalledWith(
-        //     expect.objectContaining({ cell: [0, 0], range: { x: 0, y: 0, width: 1, height: 1 } })
-        // );
     });
 
     test("Select range with mouse going out of bounds", async () => {

--- a/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor-beautiful.stories.tsx
@@ -23,7 +23,7 @@ import { SimpleThemeWrapper } from "../../stories/story-utils";
 import { useEventListener } from "../../common/utils";
 import { IBounds, useLayer } from "react-laag";
 import { SpriteMap } from "../../data-grid/data-grid-sprites";
-import { DataEditorRef } from "../..";
+import { DataEditorRef, Theme } from "../..";
 import range from "lodash/range";
 import {
     useMockDataGenerator,
@@ -309,7 +309,7 @@ export const FillHandle: React.VFC = () => {
 };
 
 const trailingRowOptionsColumnIndexesHint: Record<number, string> = {
-    2: "New row",
+    2: "Smol text",
     3: "Add",
     5: "New",
 };
@@ -324,6 +324,16 @@ const trailingRowOptionsColumnIndexesTarget: Record<number, number> = {
     2: 0,
     3: 0,
     5: 0,
+};
+
+const trailingRowOptionsColumnIndexesDisabled: Record<number, boolean> = {
+    3: true,
+};
+
+const trailingRowOptionsColumnIndexesTheme: Record<number, Partial<Theme>> = {
+    2: {
+        baseFontStyle: "10px",
+    },
 };
 
 export const TrailingRowOptions: React.VFC = () => {
@@ -347,6 +357,8 @@ export const TrailingRowOptions: React.VFC = () => {
                 hint: trailingRowOptionsColumnIndexesHint[idx],
                 addIcon: trailingRowOptionsColumnIndexesIcon[idx],
                 targetColumn: trailingRowOptionsColumnIndexesTarget[idx],
+                disabled: trailingRowOptionsColumnIndexesDisabled[idx],
+                themeOverride: trailingRowOptionsColumnIndexesTheme[idx],
             },
         }));
     }, [cols]);
@@ -1187,14 +1199,14 @@ function getColumnsForCellTypes(): GridColumnWithMockingInfo[] {
             icon: GridColumnIcon.HeaderBoolean,
             hasMenu: false,
             getContent: () => {
-                const checked = Math.random() > 0.5;
+                const roll = Math.random();
+                const checked = roll < 0.1 ? undefined : roll < 0.2 ? null : roll < 0.6;
                 // TODO: Make editable. UX looks bad by default.
                 return {
                     kind: GridCellKind.Boolean,
                     data: checked,
                     allowOverlay: false,
-                    showUnchecked: true,
-                    allowEdit: true,
+                    readonly: false,
                 };
             },
         },
@@ -2430,6 +2442,43 @@ export const Minimap: React.VFC = () => {
     options: {
         showPanel: false,
     },
+};
+
+export const ContentAlignment: React.VFC = () => {
+    const { cols, getCellContent } = useAllMockedKinds();
+
+    const mangledGetCellContent = React.useCallback<typeof getCellContent>(
+        cell => {
+            const [col, _row] = cell;
+            if (col === 3) {
+                return {
+                    ...getCellContent(cell),
+                    contentAlign: "center",
+                };
+            }
+            if (col === 4) {
+                return {
+                    ...getCellContent(cell),
+                    contentAlign: "right",
+                };
+            }
+            return getCellContent(cell);
+        },
+        [getCellContent]
+    );
+
+    return (
+        <BeautifulWrapper
+            title="Content Alignment"
+            description={
+                <Description>
+                    You can customize the content alignment by setting <PropName>contentAlign</PropName> of a cell to{" "}
+                    <PropName>left</PropName>, <PropName>right</PropName> or <PropName>center</PropName>.
+                </Description>
+            }>
+            <DataEditor {...defaultProps} getCellContent={mangledGetCellContent} columns={cols} rows={300} />
+        </BeautifulWrapper>
+    );
 };
 
 export const SpanCell: React.VFC = () => {

--- a/packages/core/src/data-editor/stories/data-editor.stories.tsx
+++ b/packages/core/src/data-editor/stories/data-editor.stories.tsx
@@ -109,8 +109,7 @@ And supports newline chars and automatic wrapping text that just needs to be lon
         return {
             kind: GridCellKind.Boolean,
             data: row % 3 === 0 || row % 5 === 0,
-            showUnchecked: true,
-            allowEdit: false,
+            readonly: true,
             allowOverlay: false,
         };
     }
@@ -642,7 +641,7 @@ export function MarkdownEdits() {
 }
 
 export const CanEditBoolean = () => {
-    const [vals, setVals] = useState<[boolean, boolean]>([false, false]);
+    const [vals, setVals] = useState<[boolean | null | undefined, boolean | null | undefined]>([false, false]);
     return (
         <DataEditor
             width="100%"
@@ -660,10 +659,9 @@ export const CanEditBoolean = () => {
             getCellContent={([col]) => {
                 return {
                     kind: GridCellKind.Boolean,
-                    allowEdit: col === 0,
+                    readonly: col !== 0,
                     allowOverlay: false,
                     data: vals[col],
-                    showUnchecked: true,
                 };
             }}
             onCellEdited={([col], newVal) => {

--- a/packages/core/src/data-editor/stories/utils.tsx
+++ b/packages/core/src/data-editor/stories/utils.tsx
@@ -54,6 +54,11 @@ export function lossyCopyData<T extends EditableGridCell>(source: EditableGridCe
                 ...target,
                 data: sourceData[0] !== undefined,
             };
+        } else if (source.kind === GridCellKind.Boolean) {
+            return {
+                ...target,
+                data: source.data,
+            };
         }
         return {
             ...target,

--- a/packages/core/src/data-editor/use-custom-cells.ts
+++ b/packages/core/src/data-editor/use-custom-cells.ts
@@ -17,40 +17,70 @@ export interface DrawArgs {
     row: number;
     highlighted: boolean;
     imageLoader: ImageWindowLoader;
+    requestAnimationFrame: () => void;
 }
 
 export type CustomCellRenderer<T extends CustomCell> = {
     isMatch: (cell: CustomCell) => cell is T;
     draw: (args: DrawArgs, cell: T) => boolean;
     provideEditor: ProvideEditorCallback<T>;
+    onPaste?: (val: string, cellData: T["data"]) => T["data"];
 };
 
-export function useCustomCells(cells: readonly CustomCellRenderer<any>[]): {
+export function useCustomCells(
+    cells: readonly CustomCellRenderer<any>[]
+): {
     drawCell: DrawCallback;
     provideEditor: ProvideEditorCallback<GridCell>;
+    coercePasteValue: NonNullable<DataEditorProps["coercePasteValue"]>;
 } {
-    const drawCell = React.useCallback<DrawCallback>(args => {
-        const { cell } = args;
-        if (cell.kind !== GridCellKind.Custom) return false;
-        for (const c of cells) {
-            if (c.isMatch(cell)) {
-                return c.draw(args, cell as any);
+    const drawCell = React.useCallback<DrawCallback>(
+        args => {
+            const { cell } = args;
+            if (cell.kind !== GridCellKind.Custom) return false;
+            for (const c of cells) {
+                if (c.isMatch(cell)) {
+                    return c.draw(args, cell as any);
+                }
             }
-        }
-        return false;
-    }, [cells]);
+            return false;
+        },
+        [cells]
+    );
 
-    const provideEditor = React.useCallback<ProvideEditorCallback<GridCell>>(cell => {
-        if (cell.kind !== GridCellKind.Custom) return undefined;
+    const provideEditor = React.useCallback<ProvideEditorCallback<GridCell>>(
+        cell => {
+            if (cell.kind !== GridCellKind.Custom) return undefined;
 
-        for (const c of cells) {
-            if (c.isMatch(cell)) {
-                return c.provideEditor(cell as any) as ReturnType<ProvideEditorCallback<GridCell>>;
+            for (const c of cells) {
+                if (c.isMatch(cell)) {
+                    return c.provideEditor(cell as any) as ReturnType<ProvideEditorCallback<GridCell>>;
+                }
             }
-        }
 
-        return undefined;
-    }, [cells]);
+            return undefined;
+        },
+        [cells]
+    );
 
-    return { drawCell, provideEditor };
+    const coercePasteValue = React.useCallback<NonNullable<DataEditorProps["coercePasteValue"]>>(
+        (val, cell) => {
+            if (cell.kind !== GridCellKind.Custom) return undefined;
+
+            for (const c of cells) {
+                if (c.isMatch(cell)) {
+                    if (c.onPaste === undefined) {
+                        return undefined;
+                    }
+                    return {
+                        ...cell,
+                        data: c.onPaste(val, cell.data),
+                    };
+                }
+            }
+        },
+        [cells]
+    );
+
+    return { drawCell, provideEditor, coercePasteValue };
 }

--- a/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx
+++ b/packages/core/src/data-grid-overlay-editor/data-grid-overlay-editor.tsx
@@ -60,11 +60,10 @@ const DataGridOverlayEditor: React.FunctionComponent<DataGridOverlayEditorProps>
 
     const onCustomFinishedEditing = React.useCallback(
         (newValue: GridCell | undefined) => {
-            newValue = newValue ?? tempValue;
             onFinishEditing(newValue, customMotion.current ?? [0, 0]);
             finished.current = true;
         },
-        [onFinishEditing, tempValue]
+        [onFinishEditing]
     );
 
     const onKeyDownCustom = React.useCallback(

--- a/packages/core/src/data-grid-overlay-editor/private/image-overlay-editor.tsx
+++ b/packages/core/src/data-grid-overlay-editor/private/image-overlay-editor.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { ImageOverlayEditorStyle } from "./image-overlay-editor-style";
 import { Carousel } from "react-responsive-carousel";
-//import "react-responsive-carousel/lib/styles/carousel.min.css";
 import { EditPencil } from "../../common/utils";
 
 export interface OverlayImageEditorProps {

--- a/packages/core/src/data-grid-overlay-editor/private/number-overlay-editor.tsx
+++ b/packages/core/src/data-grid-overlay-editor/private/number-overlay-editor.tsx
@@ -35,7 +35,7 @@ const NumberOverlayEditor: React.FunctionComponent<Props> = p => {
                 disabled={disabled === true}
                 thousandSeparator={getThousandSeprator()}
                 decimalSeparator={getDecimalSeparator()}
-                value={value ?? ""}
+                value={Object.is(value, -0) ? "-" : value ?? ""}
                 // decimalScale={3}
                 // prefix={"$"}
                 onValueChange={onChange}

--- a/packages/core/src/data-grid-search/data-grid-search.tsx
+++ b/packages/core/src/data-grid-search/data-grid-search.tsx
@@ -1,4 +1,3 @@
-// import AppIcon from "common/app-icon";
 import * as React from "react";
 import { CellArray, GetCellsThunk, GridCellKind, Item, Rectangle } from "../data-grid/data-grid-types";
 import ScrollingDataGrid, { ScrollingDataGridProps } from "../scrolling-data-grid/scrolling-data-grid";
@@ -142,7 +141,7 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
                                 testString = cell.data;
                                 break;
                             case GridCellKind.Boolean:
-                                testString = cell.data.toString();
+                                testString = typeof cell.data === "boolean" ? cell.data.toString() : undefined;
                                 break;
                             case GridCellKind.Image:
                             case GridCellKind.Bubble:
@@ -150,6 +149,9 @@ const DataGridSearch: React.FunctionComponent<DataGridSearchProps> = p => {
                                 // searching for the whale emoji, this is pretty side effect
                                 // free. And ya know... it's nice and easy to do...
                                 testString = cell.data.join("🐳");
+                                break;
+                            case GridCellKind.Custom:
+                                testString = cell.copyData;
                                 break;
                         }
 

--- a/packages/core/src/data-grid/cells/boolean-cell.tsx
+++ b/packages/core/src/data-grid/cells/boolean-cell.tsx
@@ -1,6 +1,18 @@
 import { drawBoolean } from "../data-grid-lib";
-import { GridCellKind, BooleanCell } from "../data-grid-types";
+import { GridCellKind, BooleanCell, booleanCellIsEditable } from "../data-grid-types";
 import { InternalCellRenderer } from "./cell-types";
+
+/**
+ * Checkbox behavior:
+ *
+ * true + click -> unchecked
+ * false + click -> checked
+ * indeterminate + click -> checked
+ * empty + click -> checked
+ */
+export function toggleBoolean(data: boolean | null | undefined): boolean | null | undefined {
+    return data !== true;
+}
 
 export const booleanCellRenderer: InternalCellRenderer<BooleanCell> = {
     getAccessibilityString: c => c.data?.toString() ?? "false",
@@ -9,16 +21,20 @@ export const booleanCellRenderer: InternalCellRenderer<BooleanCell> = {
     useLabel: false,
     needsHoverPosition: true,
     measure: () => 50,
-    render: a => drawBoolean(a, a.cell.data, a.cell.allowEdit),
+    render: a => drawBoolean(a, a.cell.data, booleanCellIsEditable(a.cell)),
     onDelete: c => ({
         ...c,
         data: false,
     }),
     onClick: (cell, x, y, bounds) => {
-        if (cell.allowEdit && Math.abs(x - bounds.width / 2) <= 10 && Math.abs(y - bounds.height / 2) <= 10) {
+        if (
+            booleanCellIsEditable(cell) &&
+            Math.abs(x - bounds.width / 2) <= 10 &&
+            Math.abs(y - bounds.height / 2) <= 10
+        ) {
             return {
                 ...cell,
-                data: !cell.data,
+                data: toggleBoolean(cell.data),
             };
         }
         return undefined;

--- a/packages/core/src/data-grid/cells/cell-types.ts
+++ b/packages/core/src/data-grid/cells/cell-types.ts
@@ -30,10 +30,10 @@ interface DrawArgs<T extends InnerGridCell> extends BaseDrawArgs {
 
 // intentionally mutable
 export interface PrepResult {
-    font?: string;
-    fillStyle?: string;
+    font: string | undefined;
+    fillStyle: string | undefined;
     renderer: {};
-    deprep?: (args: Pick<BaseDrawArgs, "ctx">) => void;
+    deprep: ((args: Pick<BaseDrawArgs, "ctx">) => void) | undefined;
 }
 
 type DrawCallback<T extends InnerGridCell> = (args: DrawArgs<T>) => void;

--- a/packages/core/src/data-grid/cells/index.ts
+++ b/packages/core/src/data-grid/cells/index.ts
@@ -17,7 +17,9 @@ import { uriCellRenderer } from "./uri-cell";
 // we are giving up type safety here but I cant figure out right now how to do this right.
 const asCollapsed = (x: any) => x as InternalCellRenderer<InnerGridCell>;
 
-export const CellRenderers = {
+type RendererKinds = InnerGridCellKind | Exclude<GridCellKind, GridCellKind.Custom>;
+
+export const CellRenderers: Record<RendererKinds, ReturnType<typeof asCollapsed>> = {
     [InnerGridCellKind.Marker]: asCollapsed(markerCellRenderer),
     [InnerGridCellKind.NewRow]: asCollapsed(newRowCellRenderer),
     [GridCellKind.Boolean]: asCollapsed(booleanCellRenderer),

--- a/packages/core/src/data-grid/cells/markdown-cell.tsx
+++ b/packages/core/src/data-grid/cells/markdown-cell.tsx
@@ -12,7 +12,7 @@ export const markdownCellRenderer: InternalCellRenderer<MarkdownCell> = {
     needsHoverPosition: false,
     renderPrep: prepTextCell,
     measure: () => 200,
-    render: a => drawTextCell(a, a.cell.data),
+    render: a => drawTextCell(a, a.cell.data, a.cell.contentAlign),
     onDelete: c => ({
         ...c,
         data: "",

--- a/packages/core/src/data-grid/cells/number-cell.tsx
+++ b/packages/core/src/data-grid/cells/number-cell.tsx
@@ -15,7 +15,7 @@ export const numberCellRenderer: InternalCellRenderer<NumberCell> = {
     needsHoverPosition: false,
     useLabel: true,
     renderPrep: prepTextCell,
-    render: a => drawTextCell(a, a.cell.displayData),
+    render: a => drawTextCell(a, a.cell.displayData, a.cell.contentAlign),
     measure: (ctx, cell) => ctx.measureText(cell.displayData).width + 16,
     onDelete: c => ({
         ...c,

--- a/packages/core/src/data-grid/cells/row-id-cell.tsx
+++ b/packages/core/src/data-grid/cells/row-id-cell.tsx
@@ -10,7 +10,7 @@ export const rowIDCellRenderer: InternalCellRenderer<RowIDCell> = {
     needsHover: false,
     needsHoverPosition: false,
     renderPrep: (a, b) => prepTextCell(a, b, a.theme.textLight),
-    render: a => drawTextCell(a, a.cell.data),
+    render: a => drawTextCell(a, a.cell.data, a.cell.contentAlign),
     measure: (ctx, cell) => ctx.measureText(cell.data).width + 16,
     // eslint-disable-next-line react/display-name
     getEditor: () => p => {

--- a/packages/core/src/data-grid/cells/text-cell.tsx
+++ b/packages/core/src/data-grid/cells/text-cell.tsx
@@ -12,7 +12,7 @@ export const textCellRenderer: InternalCellRenderer<TextCell> = {
     needsHoverPosition: false,
     renderPrep: prepTextCell,
     useLabel: true,
-    render: a => drawTextCell(a, a.cell.displayData),
+    render: a => drawTextCell(a, a.cell.displayData, a.cell.contentAlign),
     measure: (ctx, cell) => ctx.measureText(cell.displayData).width + 16,
     onDelete: c => ({
         ...c,
@@ -26,6 +26,7 @@ export const textCellRenderer: InternalCellRenderer<TextCell> = {
                 autoFocus={value.readonly !== true}
                 disabled={value.readonly === true}
                 onKeyDown={onKeyDown}
+                altNewline={true}
                 value={value.data}
                 onChange={e =>
                     onChange({

--- a/packages/core/src/data-grid/cells/uri-cell.tsx
+++ b/packages/core/src/data-grid/cells/uri-cell.tsx
@@ -12,7 +12,7 @@ export const uriCellRenderer: InternalCellRenderer<UriCell> = {
     needsHoverPosition: false,
     useLabel: true,
     renderPrep: prepTextCell,
-    render: a => drawTextCell(a, a.cell.data),
+    render: a => drawTextCell(a, a.cell.data, a.cell.contentAlign),
     measure: (ctx, cell) => ctx.measureText(cell.data).width + 16,
     onDelete: c => ({
         ...c,

--- a/packages/core/src/data-grid/data-grid-types.test.ts
+++ b/packages/core/src/data-grid/data-grid-types.test.ts
@@ -60,4 +60,59 @@ describe("data-grid-types", () => {
         expect(CompactSelection.empty().last()).toBeUndefined();
         expect(CompactSelection.empty().add(5).length).toBe(1);
     });
+
+    test("Smoke test compact selection remove", () => {
+        const sel = CompactSelection.fromSingleSelection([3, 8]);
+
+        expect([...sel]).toEqual([3, 4, 5, 6, 7])
+
+        // Remove entire selection
+
+        expect([...sel.remove([3, 8])]).toEqual([])
+        expect(sel.remove([3, 8]).length).toBe(0)
+
+        expect([...sel.remove([2, 9])]).toEqual([])
+        expect(sel.remove([2, 9]).length).toBe(0)
+
+        // Remove ends of selection
+
+        expect([...sel.remove([2, 6])]).toEqual([6, 7])
+        expect(sel.remove([2, 6]).length).toBe(2)
+
+        expect([...sel.remove([5, 9])]).toEqual([3, 4])
+        expect(sel.remove([5, 9]).length).toBe(2)
+
+        expect([...sel.remove([2, 3])]).toEqual([3, 4, 5, 6, 7])
+        expect(sel.remove([2, 3]).length).toBe(5)
+
+        expect([...sel.remove([8, 9])]).toEqual([3, 4, 5, 6, 7])
+        expect(sel.remove([8, 9]).length).toBe(5)
+
+        expect([...sel.remove(3)]).toEqual([4, 5, 6, 7])
+        expect(sel.remove(3).length).toBe(4)
+
+        expect([...sel.remove(7)]).toEqual([3, 4, 5, 6])
+        expect(sel.remove(7).length).toBe(4)
+
+        // Remove end and start of 2 different slices
+        const altSel = CompactSelection.fromSingleSelection([0, 5]).add([8, 12]);
+        expect([...altSel]).toEqual([0, 1, 2, 3, 4, 8, 9, 10, 11]);
+        expect([...altSel.remove([3, 10])]).toEqual([0, 1, 2, 10, 11]);
+
+        // Remove middle of selection
+
+        expect([...sel.remove([4, 7])]).toEqual([3, 7])
+        expect(sel.remove([4, 7]).length).toBe(2)
+
+        expect([...sel.remove(5)]).toEqual([3, 4, 6, 7])
+        expect(sel.remove(5).length).toBe(4)
+
+        // Remove nothing from selection
+
+        expect([...sel.remove([1, 2])]).toEqual([3, 4, 5, 6, 7])
+        expect(sel.remove([1, 2]).length).toBe(5)
+
+        expect([...sel.remove([8, 9])]).toEqual([3, 4, 5, 6, 7])
+        expect(sel.remove([8, 9]).length).toBe(5)
+    })
 });

--- a/packages/core/src/data-grid/use-animation-queue.ts
+++ b/packages/core/src/data-grid/use-animation-queue.ts
@@ -10,18 +10,25 @@ function hasItem(arr: readonly Item[], item: Item) {
 
 export function useAnimationQueue(draw: (items: readonly Item[]) => void) {
     const queue = React.useRef<Item[]>([]);
-
+    const seq = React.useRef(0);
     const drawRef = React.useRef(draw);
     drawRef.current = draw;
 
     const loop = React.useCallback(() => {
+        const requeue = () => window.requestAnimationFrame(fn);
+
         const fn = () => {
             const toDraw = queue.current;
             queue.current = [];
             drawRef.current(toDraw);
+            if (queue.current.length > 0) {
+                seq.current++;
+            } else {
+                seq.current = 0;
+            }
         };
 
-        window.requestAnimationFrame(fn);
+        window.requestAnimationFrame(seq.current > 600 ? requeue : fn);
     }, []);
 
     const enqueue = React.useCallback(

--- a/packages/core/src/growing-entry/growing-entry.tsx
+++ b/packages/core/src/growing-entry/growing-entry.tsx
@@ -7,10 +7,11 @@ interface Props
     extends React.DetailedHTMLProps<React.TextareaHTMLAttributes<HTMLTextAreaElement>, HTMLTextAreaElement> {
     readonly placeholder?: string;
     readonly highlight: boolean;
+    readonly altNewline?: boolean;
 }
 
 const GrowingEntry: React.FunctionComponent<Props> = (props: Props) => {
-    const { placeholder, value, onKeyDown, highlight, ...rest } = props;
+    const { placeholder, value, onKeyDown, highlight, altNewline, ...rest } = props;
     const { onChange, className } = rest;
 
     const inputRef = React.useRef<HTMLTextAreaElement | null>(null);
@@ -30,6 +31,16 @@ const GrowingEntry: React.FunctionComponent<Props> = (props: Props) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    const onKeyDownInner = React.useCallback<NonNullable<typeof onKeyDown>>(
+        e => {
+            if (e.key === "Enter" && e.shiftKey && altNewline === true) {
+                return;
+            }
+            onKeyDown?.(e);
+        },
+        [altNewline, onKeyDown]
+    );
+
     return (
         <GrowingEntryStyle>
             <ShadowBox className={className}>{useText + "\n"}</ShadowBox>
@@ -37,7 +48,7 @@ const GrowingEntry: React.FunctionComponent<Props> = (props: Props) => {
                 {...rest}
                 className={(rest.className ?? "") + " gdg-input"}
                 ref={inputRef}
-                onKeyDown={onKeyDown}
+                onKeyDown={onKeyDownInner}
                 value={useText}
                 placeholder={placeholder}
                 dir="auto"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,7 +12,7 @@ export { default as ImageOverlayEditor } from "./data-grid-overlay-editor/privat
 export { default as MarkdownDiv } from "./markdown-div/markdown-div";
 export { default as TextCellEntry } from "./growing-entry/growing-entry";
 export { parseToRgba } from "./data-grid/color-parser";
-export { measureTextCached } from "./data-grid/data-grid-lib";
+export { measureTextCached, getMiddleCenterBias } from "./data-grid/data-grid-lib";
 export { getDataEditorTheme as getDefaultTheme } from "./common/styles";
 export { useColumnSizer } from "./data-editor/use-column-sizer";
 export { useCustomCells } from "./data-editor/use-custom-cells";

--- a/packages/core/src/scrolling-data-grid/infinite-scroller.tsx
+++ b/packages/core/src/scrolling-data-grid/infinite-scroller.tsx
@@ -154,7 +154,9 @@ export const InfiniteScroller: React.FC<Props> = p => {
             offsetY.current = recomputed - newY;
         }
 
-        window.clearTimeout(resetHandle.current);
+        if (resetHandle.current > 0) {
+            window.clearTimeout(resetHandle.current);
+        }
         if (lock !== undefined) {
             resetHandle.current = window.setTimeout(() => {
                 const [lx, ly] = lastScrollPosition.current.lockDirection ?? [];
@@ -164,6 +166,7 @@ export const InfiniteScroller: React.FC<Props> = p => {
                     el.scrollTop = ly;
                 }
                 lastScrollPosition.current.lockDirection = undefined;
+                resetHandle.current = 0;
             }, 200);
         }
 

--- a/packages/core/src/stories/story-utils.tsx
+++ b/packages/core/src/stories/story-utils.tsx
@@ -83,39 +83,3 @@ export const SimpleThemeWrapper: React.FC = p => {
         </ThemeProvider>
     );
 };
-
-// export function permuteAll(
-//   allOptions: Record<string, any[]>,
-//   combine: boolean = true
-// ): any[] {
-//   let result: any[] = [
-//     {
-//       name: "",
-//     },
-//   ];
-//   const keys = Object.keys(allOptions);
-//   keys.forEach((o) => {
-//     result = reduceOption(allOptions[o], o, result, combine);
-//   });
-
-//   return result;
-// }
-
-// export function permuteSeparate(allOptions: Record<string, any[]>): any[] {
-//   return permuteAll(allOptions, false);
-// }
-
-// export const loremIpsum =
-//   "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.";
-
-// const DummyAppEnv: AppEnvironment = ({
-//   // If this gets used we are going to crash anyway
-// } as unknown) as AppEnvironment;
-// export const DummyRenderEnv: RenderEnvironment = new RenderEnvironment(
-//   DummyAppEnv,
-//   {
-//     displayContext: "default",
-//     sizeClass: "phone",
-//     needsRerender: false,
-//   }
-// );

--- a/packages/core/tsconfig.types.json
+++ b/packages/core/tsconfig.types.json
@@ -6,7 +6,7 @@
         "declaration": true,
         "emitDeclarationOnly": true,
         "isolatedModules": false,
-        "lib": ["ESNext", "DOM"],
+        "lib": ["ESNext", "DOM", "DOM.Iterable"],
         "noEmit": false,
         "outDir": "dist/ts",
         "sourceMap": false,

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -1,64 +1,64 @@
 {
-  "name": "@glideapps/glide-data-grid-source",
-  "version": "4.0.3",
-  "description": "Useful data source hooks for Glide Data Grid",
-  "sideEffects": false,
-  "type": "module",
-  "browser": "dist/js/index.js",
-  "main": "dist/cjs/index.js",
-  "module": "dist/js/index.js",
-  "types": "dist/ts/index.d.ts",
-  "exports": {
-    "import": "./dist/js/index.js",
-    "require": "./dist/cjs/index.js"
-  },
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "npm run build-js && npm run build-cjs && npm run build-types",
-    "build-js": "babel --config-file ../../babel.config.json ./src -d dist/js --ignore '**/*.stories.tsx','src/stories/*.tsx' --extensions .ts,.tsx && tsc-esm-fix --target='dist/js'",
-    "build-cjs": "babel --config-file ../../babel.cjs.json ./src -d dist/cjs --ignore '**/*.stories.tsx','src/stories/*.tsx' --extensions .ts,.tsx",
-    "build-types": "tsc -p tsconfig.types.json",
-    "lint": "eslint src --ext .ts,.tsx",
-    "test": "NODE_OPTIONS='--experimental-modules' jest"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/glideapps/glide-data-grid.git",
-    "directory": "packages/source"
-  },
-  "homepage": "https://github.com/glideapps/glide-data-grid/tree/main/cells",
-  "author": "Glide",
-  "license": "MIT",
-  "keywords": [
-    "react",
-    "datagrid",
-    "data-grid",
-    "editor",
-    "reactjs",
-    "scrolling",
-    "data",
-    "table",
-    "cell",
-    "canvas"
-  ],
-  "dependencies": {
-    "@glideapps/glide-data-grid": "4.0.3"
-  },
-  "peerDependencies": {
-    "lodash": "^4.17.19",
-    "react": "^16.12.0 || 17.x || 18.x",
-    "react-dom": "^16.12.0 || 17.x || 18.x"
-  },
-  "devDependencies": {
-    "@babel/cli": "^7.16.0",
-    "styled-components": "^5.2.0",
-    "eslint": "^7.12.1",
-    "eslint-plugin-import": "^2.22.0",
-    "eslint-plugin-react": "^7.21.5",
-    "eslint-plugin-react-hooks": "^4.2.0",
-    "jest": "^27.4.2",
-    "tsc-esm-fix": "^2.7.8"
-  }
+    "name": "@glideapps/glide-data-grid-source",
+    "version": "4.1.0",
+    "description": "Useful data source hooks for Glide Data Grid",
+    "sideEffects": false,
+    "type": "module",
+    "browser": "dist/js/index.js",
+    "main": "dist/cjs/index.js",
+    "module": "dist/js/index.js",
+    "types": "dist/ts/index.d.ts",
+    "exports": {
+        "import": "./dist/js/index.js",
+        "require": "./dist/cjs/index.js"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "npm run build-js && npm run build-cjs && npm run build-types",
+        "build-js": "babel --config-file ../../babel.config.json ./src -d dist/js --ignore '**/*.stories.tsx','src/stories/*.tsx' --extensions .ts,.tsx && tsc-esm-fix --target='dist/js'",
+        "build-cjs": "babel --config-file ../../babel.cjs.json ./src -d dist/cjs --ignore '**/*.stories.tsx','src/stories/*.tsx' --extensions .ts,.tsx",
+        "build-types": "tsc -p tsconfig.types.json",
+        "lint": "eslint src --ext .ts,.tsx",
+        "test": "NODE_OPTIONS='--experimental-modules' jest"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/glideapps/glide-data-grid.git",
+        "directory": "packages/source"
+    },
+    "homepage": "https://github.com/glideapps/glide-data-grid/tree/main/cells",
+    "author": "Glide",
+    "license": "MIT",
+    "keywords": [
+        "react",
+        "datagrid",
+        "data-grid",
+        "editor",
+        "reactjs",
+        "scrolling",
+        "data",
+        "table",
+        "cell",
+        "canvas"
+    ],
+    "dependencies": {
+        "@glideapps/glide-data-grid": "4.1.0"
+    },
+    "peerDependencies": {
+        "lodash": "^4.17.19",
+        "react": "^16.12.0 || 17.x || 18.x",
+        "react-dom": "^16.12.0 || 17.x || 18.x"
+    },
+    "devDependencies": {
+        "@babel/cli": "^7.16.0",
+        "styled-components": "^5.2.0",
+        "eslint": "^7.12.1",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-react": "^7.21.5",
+        "eslint-plugin-react-hooks": "^4.2.0",
+        "jest": "^27.4.2",
+        "tsc-esm-fix": "^2.7.8"
+    }
 }

--- a/packages/source/src/use-collapsing-groups.ts
+++ b/packages/source/src/use-collapsing-groups.ts
@@ -63,8 +63,6 @@ export function useCollapsingGroups(props: Props): Result {
                     let width = 8;
                     if (index === start + length - 1) {
                         width = 36;
-                    } else if (index <= start + 1) {
-                        width = 8;
                     }
 
                     return {


### PR DESCRIPTION
* 4.0.4-alpha1

* Greatly expand support for styling the trailing row

* Support indeterminate and empty states for boolean cell (#310)

* Fix issue with missing cjs dist in beta release CI (#307)

Related to https://github.com/glideapps/glide-data-grid/issues/299

* Support indeterminate and empty states for boolean cell

* Just forward the focus call to DataGrid

* Fix copy data for boolean cells

* Fix test for React 18

* Fix type error in story

* New empty behavior

* Don't even render false state if empty && cant edit

* Update lying comment

* Remove unnecessary check

* Add early return

* Improve types

Co-authored-by: Lukas Masuch <Lukas.Masuch@gmail.com>
Co-authored-by: Jason Smith <jason@heyglide.com>

* Deprecate showUnchecked

* Better newline handling for editors

* Minor correctness improvements

* Fixup clipboard handling so the data grid can differentiate display values and real values (#329)

* Fixup clipboard handling so the data grid can differentiate display values and real values

* Fix build

* Include custom cells in search

* support removing a slice in CompactSelection.remove (#325)

* support removing a slice in CompactSelection.remove

* fix intersection condition + add unit tests

* fix invalid items + add tests checking for lengths

* fix missing semicolons + new lines

* Fix tests

* Cleanup test warnings

* Minor cleanup

* Fix ideal height not counting trailing row (#330)

* Allow experimentally setting the scrollbar width override

* maintain-focus-when-cell-outside-viewport (#326)

* Fix compile errors

* Allow custom editors to cancel editing

* Allow typing - to start editing a number and be more permissive in general

* 4.0.4-beta1

* Fix dragging grid interaction

* 4.0.4-beta2

* Hide vertical and horizontal border on edges (#332)

* Add support for text alignment in theme (#331)

* Add support for text alignment

* Add content align cell property

* Add story for content alignment

* Use cell from draw args

* remove any

* paste improvements (#334)

* Improve paste API

* Add mass edit callback

* Fix tests

* Update docs

* Add content align to additional cells (#335)

* Cleanup paste

* 4.0.4-beta3

* Enable easy paste handling for custom cells (#345)

* Add API for paste coercion

* Fix build

* Reduce shape changes in render hot path

* Remove breaking change

* Add middle center bias algorithm (#342)

* Add middle center bias algorithm

* Use more places and reduce perf overhead

* Fix readme

* Support middle center bias on all of our custom cells

* Apply middle center bias to headers

* Implement simple animation support and add auto-throttle to half framerate after 600 frames of animation.

* Fix build

* 4.1.0-beta1

* Optimize middle center bias cache hit

* This time really commit the code

* Improve API docs slightly

* Prep for stable

Co-authored-by: Ivo Elbert <ivo.elbert1@gmail.com>
Co-authored-by: Lukas Masuch <Lukas.Masuch@gmail.com>
Co-authored-by: Brian Hung <brianlhung@gmail.com>